### PR TITLE
CNICS DB Placeholder

### DIFF
--- a/docker-compose.cnics.dev.yaml
+++ b/docker-compose.cnics.dev.yaml
@@ -1,0 +1,15 @@
+version: "3.4"
+services:
+  cnics-db:
+    image: mariadb:10.6
+    environment:
+      MYSQL_ROOT_PASSWORD: cnics@CIRG
+      MYSQL_DATABASE: cnics
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: cnics@CIRG
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - internal
+volumes:
+  mysql-data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     depends_on:
       - mssql
     volumes:
-      - ./src/server:/app
       - ${KEYS:-./src/server/keys}:/.keys
     environment:
       LEAF_JWT_KEY_PW: ${JWT_KEY_PW}
@@ -42,9 +41,6 @@ services:
       context: ./src/ui-client
     depends_on:
       - coreapi
-    volumes:
-      - ./src/ui-client:/app
-
 volumes:
   leaf-mssql:
 

--- a/src/server/API/appsettings.json
+++ b/src/server/API/appsettings.json
@@ -62,7 +62,7 @@
   },
   "Compiler": {
     "Alias": "@",
-    "FieldPersonId": "person_id", 
+    "FieldPersonId": "PatientId",
     "FieldEncounterId": "visit_occurrence_id"
   },
   "Cohort": {

--- a/src/server/API/appsettings.json
+++ b/src/server/API/appsettings.json
@@ -16,7 +16,7 @@
     "Clin": {
       "Connection": "LEAF_CLIN_DB",
       "DefaultTimeout": 180,
-      "RDBMS":  "MSSQL",
+      "RDBMS":  "MARIADB",
       "Cohort": {
         "QueryStrategy": "PARALLEL",
         "MaxParallelThreads": 5

--- a/src/ui-client/package.json
+++ b/src/ui-client/package.json
@@ -71,7 +71,6 @@
   "resolutions": {
     "react-scripts/**/eslint-config-react-app": "7.0.1"
   },
-  "proxy": "http://localhost:5001",
   "browserslist": [
     ">0.2%",
     "not dead",


### PR DESCRIPTION
- Add mariadb service as placeholder for CNICS clinical DB
- Switch default ClinDB type from MSSQL to mariadb
- Reconfigure `FieldPersonId` for CNICS Patients primary key (PatientId)

#### TODO
- [ ] Research if (above) config values can be set at run-time (via environment variable, eg `LEAF_CLIN_DB`) 
- [x] Update mariadb credentials (to be more obviously from CNICS)
- [ ] Remove javascript proxy dev workaround