### PR TITLE
Replace "patient(s)" with "participant(s)" in frontend code

### DIFF
--- a/src/ui-client/src/components/Admin/ConceptEditor/Sections/Display.tsx
+++ b/src/ui-client/src/components/Admin/ConceptEditor/Sections/Display.tsx
@@ -39,7 +39,7 @@ export class Display extends React.PureComponent<Props> {
                 />
                 <Input 
                     changeHandler={changeHandler} propName={'uiDisplayPatientCount'} value={adminConcept!.uiDisplayPatientCount}
-                    label='Patient Count' type='number' subLabel='Total patient count displayed next to name'
+                    label='Participant Count' type='number' subLabel='Total participant count displayed next to name'
                 />
                 <Input 
                     changeHandler={changeHandler} propName={'uiDisplayUnits'} value={adminConcept!.uiDisplayUnits}

--- a/src/ui-client/src/components/FindPatients/Panels/InclusionDropdown.tsx
+++ b/src/ui-client/src/components/FindPatients/Panels/InclusionDropdown.tsx
@@ -48,8 +48,8 @@ export default class InclusionDropdown extends React.PureComponent<Props, State>
         // Set the text and options to display, depending on inclusion state and
         // whether it is the first panel or not
         if (isFirst) { 
-            opts = [ 'Patients Who', 'Not Patients Who' ];
-            displayText = isInclusionCriteria ? 'Patients Who' : 'Not Patients Who';
+            opts = [ 'Participants Who', 'Not Participants Who' ];
+            displayText = isInclusionCriteria ? 'Participants Who' : 'Not Participants Who';
         }
         else {
             opts = [ 'And', 'And Not' ];
@@ -83,7 +83,7 @@ export default class InclusionDropdown extends React.PureComponent<Props, State>
     private selectItem = (item: any) => {
         const { index, inclusionDropdownType, panel, handlers } = this.props;
         const text = item.target.innerText;
-        const include = text === 'Patients Who' || text === 'And' ? true : false;
+        const include = text === 'Participants Who' || text === 'And' ? true : false;
 
         // Update state
         if (inclusionDropdownType === INCLUSION_DROPDOWN_TYPE.PANEL) {

--- a/src/ui-client/src/config/routes.tsx
+++ b/src/ui-client/src/config/routes.tsx
@@ -36,7 +36,7 @@ interface SubRouteConfig {
 
 const findPatients = (): RouteConfig => {
     return {   
-        display: 'Find Patients', 
+        display: 'Explore Data',
         icon: <FiSearch />,
         index: Routes.FindPatients,
         path: '/', 

--- a/src/ui-client/src/config/routes.tsx
+++ b/src/ui-client/src/config/routes.tsx
@@ -76,7 +76,7 @@ const timelines = (): RouteConfig => {
 };
 const patientList = (): RouteConfig => { 
     return {
-        display: 'Patient List', 
+        display: 'Participant List', 
         icon: <MdPerson />,
         index: Routes.PatientList,
         path: '/patientList', 


### PR DESCRIPTION
This pull request aims to replace occurrences of "patient" within the TypeScript used for the Leaf frontend with "participant" in strings displayed within the page UI.