### PR TITLE
Replace MySql.Data NuGet package with MySqlConnector

### DIFF
--- a/src/server/Services/Compiler/SqlProviderQueryExecutor.cs
+++ b/src/server/Services/Compiler/SqlProviderQueryExecutor.cs
@@ -86,21 +86,21 @@ namespace Services.Compiler
      */
     public class MySqlQueryExecutor : BaseQueryExecutor
     {
-        MySql.Data.MySqlClient.MySqlDbType ToSqlType(object val)
+        MySqlConnector.MySqlDbType ToSqlType(object val)
         {
-            if (val is string)   return MySql.Data.MySqlClient.MySqlDbType.String;
-            if (val is decimal)  return MySql.Data.MySqlClient.MySqlDbType.Decimal;
-            if (val is double)   return MySql.Data.MySqlClient.MySqlDbType.Double;
-            if (val is int)      return MySql.Data.MySqlClient.MySqlDbType.Int32;
-            if (val is bool)     return MySql.Data.MySqlClient.MySqlDbType.Bit;
-            if (val is Guid)     return MySql.Data.MySqlClient.MySqlDbType.Guid;
-            if (val is DateTime) return MySql.Data.MySqlClient.MySqlDbType.DateTime;
-            return MySql.Data.MySqlClient.MySqlDbType.String;
+            if (val is string)   return MySqlConnector.MySqlDbType.String;
+            if (val is decimal)  return MySqlConnector.MySqlDbType.Decimal;
+            if (val is double)   return MySqlConnector.MySqlDbType.Double;
+            if (val is int)      return MySqlConnector.MySqlDbType.Int32;
+            if (val is bool)     return MySqlConnector.MySqlDbType.Bit;
+            if (val is Guid)     return MySqlConnector.MySqlDbType.Guid;
+            if (val is DateTime) return MySqlConnector.MySqlDbType.DateTime;
+            return MySqlConnector.MySqlDbType.String;
         }
 
-        MySql.Data.MySqlClient.MySqlParameter ToSqlParameter(QueryParameter q)
+        MySqlConnector.MySqlParameter ToSqlParameter(QueryParameter q)
         {
-            var parameter = new MySql.Data.MySqlClient.MySqlParameter($"?{q.Name}", ToSqlType(q.Value));
+            var parameter = new MySqlConnector.MySqlParameter($"?{q.Name}", ToSqlType(q.Value));
             parameter.Value = q.Value;
 
             return parameter;
@@ -114,11 +114,11 @@ namespace Services.Compiler
             IEnumerable<QueryParameter> parameters)
         {
             // Open connection
-            var conn = new MySql.Data.MySqlClient.MySqlConnection(connStr);
+            var conn = new MySqlConnector.MySqlConnection(connStr);
             await conn.OpenAsync();
 
             // Create command
-            var cmd = new MySql.Data.MySqlClient.MySqlCommand(query, conn);
+            var cmd = new MySqlConnector.MySqlCommand(query, conn);
             cmd.CommandTimeout = timeout;
             cmd.Parameters.AddRange(parameters.Select(p => ToSqlParameter(p)).ToArray());
 

--- a/src/server/Services/Services.csproj
+++ b/src/server/Services/Services.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="MySql.Data" Version="8.0.28" />
+    <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="Npgsql" Version="6.0.2" />
     <PackageReference Include="System.Data.OracleClient" Version="1.0.8" />
     <PackageReference Include="Google.Cloud.BigQuery.V2" Version="2.3.0" />
@@ -44,7 +44,7 @@
   <ItemGroup>
     <None Remove="Admin\Notification\" />
     <None Remove="Compiler\" />
-    <None Remove="MySql.Data" />
+    <None Remove="MySqlConnector" />
     <None Remove="Npgsql" />
     <None Remove="System.Data.OracleClient" />
     <None Remove="Google.Cloud.BigQuery.V2" />


### PR DESCRIPTION
When merged, this PR will replace

- `MySql.Data` v8.0.28

for the following package and version

- `MySqlConnector` v2.3.7

Prior to using this package, we would repeatedly see the following error in the Docker container logs, in spite of efforts to modify the connection string as the error seems to suggest may be required:

```
MySql.Data.MySqlClient.MySqlException (0x80004005): Unable to connect to any of the specified MySql hosts.
 ---> System.ArgumentException: The parameter 'host' cannot be an empty string.
```

Posts [here](https://stackoverflow.com/questions/60067296/unable-to-connect-to-any-of-the-specified-mysql-hosts-c-sharp-heroku-cleard) and [here](https://bugs.mysql.com/bug.php?id=97448) recommended replacing `MySql.Data` with the `MySqlConnector` package instead. After doing this and rebuilding the containers, the error was no longer present in the logs.

Note that `MySqlConnector` is almost entirely a drop-in replacement for `MySql.Data`, the APIs are nearly identical. `MySqlConnector` also allows additional configuration options not present in `MySql.Data`.

Anecdotally, this package appears faster within our own environment, and benchmarks by the package author support this observation as well:

![image](https://github.com/user-attachments/assets/754d683b-0689-48aa-b180-ef19673e5caa)
