### PR TITLE
add frontend piwik tracking code

### DIFF
--- a/src/ui-client/src/containers/App.tsx
+++ b/src/ui-client/src/containers/App.tsx
@@ -33,6 +33,7 @@ import DataImportContainer from '../containers/DataImport/DataImport';
 import UserQuestionModal from './UserQuestionModal/UserQuestionModal';
 import { SavedQueryMap } from '../models/Query';
 import { sleep } from '../utils/Sleep';
+import { addMatomoTracking } from '../utils/piwik';
 import NotificationModal from '../components/Modals/NotificationModal/NotificationModal';
 import MaintainenceModal from '../components/Modals/MaintainenceModal/MaintainenceModal';
 import './App.css';
@@ -74,6 +75,7 @@ class App extends React.Component<Props> {
         this.handleSessionTokenRefresh();
         dispatch(getIdToken());
         dispatch(refreshServerStateLoop());
+        addMatomoTracking();
     }
 
     public componentDidUpdate() { 

--- a/src/ui-client/src/utils/envConfig.ts
+++ b/src/ui-client/src/utils/envConfig.ts
@@ -21,6 +21,7 @@ export async function fetchEnvData(): Promise<any> {
         if (results[1].value) {
             returnResults = {
                 ...returnResults,
+                // user auth/context info will be under the `user` key
                 user: results[1].value
             }
         }

--- a/src/ui-client/src/utils/envConfig.ts
+++ b/src/ui-client/src/utils/envConfig.ts
@@ -1,0 +1,77 @@
+import Axios from "axios";
+import { getAuthConfig, getUserTokenAndContext } from "../services/authApi";
+interface EnvVar {
+  key: string;
+  value: string | object;
+}
+
+export async function fetchEnvData(): Promise<any> {
+  return new Promise((resolve) => {
+    // fetch data from appsettings.json and env.json
+    Promise.allSettled([
+      getAuthConfig().then((config) => config), // general config settings
+      getAuthConfig().then((config) => getUserTokenAndContext(config)), // user auth specific settings
+      Axios.get("/env.json"), // env.json, generated via script to be populated with environment variables
+    ])
+      .then((results) => {
+        let returnResults = {};
+        if (results[0].value) {
+            returnResults = results[0].value;
+        }
+        if (results[1].value) {
+            returnResults = {
+                ...returnResults,
+                user: results[1].value
+            }
+        }
+        if (results[2].value && results[2].value.data) {
+            returnResults = {
+                ...returnResults,
+                ...results[2].value.data
+            }
+        }
+        resolve(returnResults);
+      })
+      .catch((e) => resolve(null));
+  });
+}
+// data coming from appsettings && env.json
+export async function getEnvData() {
+  const results = await fetchEnvData();
+  if (window && results) {
+    window["appConfig"] = results;
+    console.table("Environment variables:",getEnvs());
+  }
+  return results;
+}
+export function getEnv(key: string) {
+  //window application global variables
+  if (window && window["appConfig"] && window["appConfig"][key])
+    return window["appConfig"][key];
+  const envDefined = typeof process !== "undefined" && process.env;
+  //enviroment variables as defined by Node
+  if (envDefined && process.env[key]) return process.env[key];
+  return "";
+}
+
+export function getEnvs(): EnvVar[] {
+  let arrEnvs: EnvVar[] = [];
+  const BLACK_LIST = ["SECRET", "KEY", "TOKEN", "CREDENTIALS"];
+  if (window && window["appConfig"]) {
+    const keys = Object.keys(window["appConfig"]);
+    keys.forEach((key) => {
+      if (BLACK_LIST.indexOf(key.toUpperCase()) !== -1) return true;
+      arrEnvs.push({ key: key, value: window["appConfig"][key] });
+    });
+  }
+  const envDefined = typeof process !== "undefined" && process.env;
+  if (envDefined) {
+    const envKeys = Object.keys(process.env);
+    envKeys.forEach((key) => {
+      if (BLACK_LIST.indexOf(key.toUpperCase()) !== -1) return true;
+      arrEnvs.push({ key: key, value: process.env[key] });
+    });
+  }
+  console.log("Environment variables ", arrEnvs);
+  return arrEnvs;
+}

--- a/src/ui-client/src/utils/piwik.ts
+++ b/src/ui-client/src/utils/piwik.ts
@@ -12,11 +12,14 @@ export function getUserIdFromEnv(config) : number | string | null {
 // get PIWIK siteId from environment variable
 export function getMatomoSiteIdFromEnv(config) : number | null{
     if (!config) return null;
-    if (config["REACT_APP_MATOMO_SITE_ID"]) return config["REACT_APP_MATOMO_SITE_ID"];
-    if (config["MATOMO_SITE_ID"]) return config["MATOMO_SITE_ID"];
-    if (config["REACT_APP_PIWIK_SITE_ID"]) return config["REACT_APP_PIWIK_SITE_ID"];
-    if (config["PIWIK_SITE_ID"]) return config["PIWIK_SITE_ID"];
-    return config["SITE_ID"];
+    const envs = config.client ? config.client: config;
+    // appsettings.json {client: .....}
+    // env.json
+    if (envs["REACT_APP_MATOMO_SITE_ID"]) return envs["REACT_APP_MATOMO_SITE_ID"];
+    if (envs["MATOMO_SITE_ID"]) return envs["MATOMO_SITE_ID"];
+    if (envs["REACT_APP_PIWIK_SITE_ID"]) return envs["REACT_APP_PIWIK_SITE_ID"];
+    if (envs["PIWIK_SITE_ID"]) return envs["PIWIK_SITE_ID"];
+    return envs["SITE_ID"];
 }
 export async function addMatomoTracking() {
     // already generated script, return

--- a/src/ui-client/src/utils/piwik.ts
+++ b/src/ui-client/src/utils/piwik.ts
@@ -34,6 +34,7 @@ export async function addMatomoTracking() {
     // no site Id return
     if (!siteId) return;
     // init global piwik tracking object
+    // note this will only be executed if BOTH userId and siteId are present
     window._paq = [];
     window._paq.push(["trackPageView"]);
     window._paq.push(["enableLinkTracking"]);

--- a/src/ui-client/src/utils/piwik.ts
+++ b/src/ui-client/src/utils/piwik.ts
@@ -1,0 +1,52 @@
+import {getEnvData} from "./envConfig";
+
+// get user Id from config, i.e. see getAuthConfig, getUserTokenAndContext from authAPI
+export function getUserIdFromEnv(config) : number | string | null {
+    if (!config) return null;
+    if (config.user && config.user.name) return config.user.name;
+    if (config.profile) return config.profile;
+    if (config.fhirUser) return config.fhirUser;
+    if (config["preferred_username"]) return config["preferred_username"];
+    return null;
+}
+// get PIWIK siteId from environment variable
+export function getMatomoSiteIdFromEnv(config) : number | null{
+    if (!config) return null;
+    if (config["REACT_APP_MATOMO_SITE_ID"]) return config["REACT_APP_MATOMO_SITE_ID"];
+    if (config["MATOMO_SITE_ID"]) return config["MATOMO_SITE_ID"];
+    if (config["REACT_APP_PIWIK_SITE_ID"]) return config["REACT_APP_PIWIK_SITE_ID"];
+    if (config["PIWIK_SITE_ID"]) return config["PIWIK_SITE_ID"];
+    return config["SITE_ID"];
+}
+export async function addMatomoTracking() {
+    // already generated script, return
+    if (!window || document.querySelector("#matomoScript")) return;
+    const envData = await getEnvData();
+    const userId = getUserIdFromEnv(envData);
+    console.log("PIWIK userId ", userId);
+    // no user Id return
+    if (!userId) return;
+    const siteId = getMatomoSiteIdFromEnv(envData);
+    console.log("PIWIK siteId ", siteId)
+    // no site Id return
+    if (!siteId) return;
+    // init global piwik tracking object
+    window._paq = [];
+    window._paq.push(["trackPageView"]);
+    window._paq.push(["enableLinkTracking"]);
+    window._paq.push(["setSiteId", siteId]);
+    window._paq.push(["setUserId", userId]);
+  
+    let u = "https://piwik.cirg.washington.edu/";
+    window._paq.push(["setTrackerUrl", u + "matomo.php"]);
+    let d = document,
+      g = d.createElement("script"),
+      headElement = document.querySelector("head");
+    g.type = "text/javascript";
+    g.async = true;
+    g.defer = true;
+    g.setAttribute("src", u + "matomo.js");
+    g.setAttribute("id", "matomoScript");
+    headElement.appendChild(g);
+  }
+  

--- a/src/ui-client/src/utils/piwik.ts
+++ b/src/ui-client/src/utils/piwik.ts
@@ -52,4 +52,3 @@ export async function addMatomoTracking() {
     g.setAttribute("id", "matomoScript");
     headElement.appendChild(g);
   }
-  


### PR DESCRIPTION
Add PIWIK Tracking
- UserId for PIWIK tracking is retrieved via user JWT  IDToken, see screenshot (note the key `name`), for reference, see [here](https://github.com/uwcirg/leaf/blob/3943b12d80a940efc36a1f261f6ed10d8ddbb212/src/ui-client/src/services/authApi.ts#L24) via call to [AuthConfig API](https://github.com/uwcirg/leaf/blob/3943b12d80a940efc36a1f261f6ed10d8ddbb212/src/ui-client/src/services/authApi.ts#L124C14-L124C27)
<img width="1335" alt="Screenshot 2024-12-31 at 10 46 55 AM" src="https://github.com/user-attachments/assets/31285831-e3f5-4798-85a3-958c85deea11" />

- Site ID for PIWIK tracking is retrieved via environment variable set in either `appsettings.json` (under key `client`)  or `env.json`.  (TBD)   The code will look in either one of these regardless.  Any one of those variables will work: 
  - REACT_APP_MATOMO_SITE_ID
  - MATOMO_SITE_ID
  - REACT_APP_PIWIK_SITE_ID
  - PIWIK_SITE_ID
  - SITE_ID 
  
- The PIWIK tracking code will not run if either `userId` or siteId` is null/undefined
  
**Note** If adding piwik site Id under  the key `client` in `appsettings.json` changing code is required [see here](https://github.com/uwcirg/leaf/blob/master/src/server/API/DTO/Config/ConfigDTO.cs#L69) for the new key-value pair to be returned.
**Note** If using `env.json`, new script (like [this](https://github.com/uwcirg/cosri-pain-management-summary/blob/develop/docker-entrypoint.sh#L25)) is required to populate it with environment variables needed by the frontend