### PR TITLE
Fixup/query info text location

### DIFF
--- a/src/ui-client/src/components/FindPatients/ConceptSearchBox/ConceptSearchBox.tsx
+++ b/src/ui-client/src/components/FindPatients/ConceptSearchBox/ConceptSearchBox.tsx
@@ -157,9 +157,8 @@ export default class ConceptSearchBox extends React.PureComponent<Props, State> 
     }
 
     public renderQueryInfo() {
-        return <div className="text-muted mt-4 ml-4">( To query, drag and drop concepts into boxes to the right )</div>
+        return <div className="text-muted mt-4 ml-4 mb-1">( To query, drag and drop concepts into boxes to the right )</div>
     }
-
 
     private toggleRootsDropdown = () => {
         this.setState({ showRootsDropdown: !this.state.showRootsDropdown });

--- a/src/ui-client/src/components/FindPatients/ConceptSearchBox/ConceptSearchBox.tsx
+++ b/src/ui-client/src/components/FindPatients/ConceptSearchBox/ConceptSearchBox.tsx
@@ -151,9 +151,15 @@ export default class ConceptSearchBox extends React.PureComponent<Props, State> 
                         }
                     </div>
                 </InputGroup>
+                {this.renderQueryInfo()}
             </div>
         )
     }
+
+    public renderQueryInfo() {
+        return <div className="text-muted mt-4 ml-4">( To query, drag and drop concepts into boxes to the right )</div>
+    }
+
 
     private toggleRootsDropdown = () => {
         this.setState({ showRootsDropdown: !this.state.showRootsDropdown });

--- a/src/ui-client/src/components/FindPatients/Panels/PanelGroupColumn.tsx
+++ b/src/ui-client/src/components/FindPatients/Panels/PanelGroupColumn.tsx
@@ -98,6 +98,11 @@ class PanelGroupColumn extends React.Component<Props> {
         }
     }
 
+    public renderQueryInfo(queryState : string) {
+        if (queryState !== CohortStateType.NOT_LOADED) return null;
+        return <div className="text-muted text-center mb-1">( To query, drag and drop concepts into boxes below )</div>
+    }
+
     public render() {
         const { dispatch, panels, panelFilters, queryState } = this.props;
         return (
@@ -107,6 +112,7 @@ class PanelGroupColumn extends React.Component<Props> {
                         <span>{this.setRunQueryButtonContent()}</span>
                     </div>
                 </div>
+                {this.renderQueryInfo(queryState)}
                 <PanelFilterGroup dispatch={dispatch} filters={panelFilters} />
                 <PanelGroup dispatch={dispatch} panels={panels} queryState={queryState} />
             </div>

--- a/src/ui-client/src/components/FindPatients/Panels/PanelGroupColumn.tsx
+++ b/src/ui-client/src/components/FindPatients/Panels/PanelGroupColumn.tsx
@@ -98,11 +98,6 @@ class PanelGroupColumn extends React.Component<Props> {
         }
     }
 
-    public renderQueryInfo(queryState : string) {
-        if (queryState !== CohortStateType.NOT_LOADED) return null;
-        return <div className="text-muted text-center mb-1">( To query, drag and drop concepts into boxes below )</div>
-    }
-
     public render() {
         const { dispatch, panels, panelFilters, queryState } = this.props;
         return (
@@ -112,7 +107,6 @@ class PanelGroupColumn extends React.Component<Props> {
                         <span>{this.setRunQueryButtonContent()}</span>
                     </div>
                 </div>
-                {this.renderQueryInfo(queryState)}
                 <PanelFilterGroup dispatch={dispatch} filters={panelFilters} />
                 <PanelGroup dispatch={dispatch} panels={panels} queryState={queryState} />
             </div>


### PR DESCRIPTION
per feedback from the meeting,
move query info text near the concept search box on the right.
(see screenshot)
![Screenshot 2025-02-07 at 11 16 43 AM](https://github.com/user-attachments/assets/5cb1bbc4-2c55-4af7-a40c-aa43e28444cf)
