### PR TITLE
fix code for retrieving piwik siteId from environment variable

### DIFF
--- a/src/ui-client/src/utils/piwik.ts
+++ b/src/ui-client/src/utils/piwik.ts
@@ -10,11 +10,8 @@ export function getUserIdFromEnv(config) : number | string | null {
     return null;
 }
 // get PIWIK siteId from environment variable
-export function getMatomoSiteIdFromEnv(config) : number | null{
-    if (!config) return null;
-    const envs = config.client ? config.client: config;
-    // appsettings.json {client: .....}
-    // env.json
+export function getMatomoSiteIdFromEnv(envs) : number | null{
+    if (!envs) return null;
     if (envs["REACT_APP_MATOMO_SITE_ID"]) return envs["REACT_APP_MATOMO_SITE_ID"];
     if (envs["MATOMO_SITE_ID"]) return envs["MATOMO_SITE_ID"];
     if (envs["REACT_APP_PIWIK_SITE_ID"]) return envs["REACT_APP_PIWIK_SITE_ID"];


### PR DESCRIPTION
Issue: Matomo site ID isn't being read  from environment variable in the staging instance.
Fix: remove code from before that tried to retrieve it specifically from `appsettings.json` (under the key 'client')
(see screenshot of environment variables structure from staging)
<img width="511" alt="Screenshot 2025-02-10 at 2 22 38 PM" src="https://github.com/user-attachments/assets/ec636549-f8ce-4224-916c-34f935fb7bd4" />

