### PR TITLE
Skip mode selection: set de-identify to false

### DIFF
--- a/src/ui-client/src/containers/Attestation/Attestation.tsx
+++ b/src/ui-client/src/containers/Attestation/Attestation.tsx
@@ -99,7 +99,7 @@ class Attestation extends React.PureComponent<Props, State> {
                     sessionTypeSelected: true, 
                     documentationStatusSelected: true, 
                     identificationTypeSelected: true,
-                    attestation: { ...this.state.attestation, isIdentified: !config.cohort.deidentificationEnabled }
+                    attestation: { ...this.state.attestation, isIdentified: false }
                 });
             }
         }


### PR DESCRIPTION
based on the [code](https://github.com/uwcirg/leaf/blob/50cf69dc702812fda95d6810c7a453d0e004523f/src/ui-client/src/actions/session.ts#L199) here, attestation's `isIdentified` property should be false when SkipModeSelection is configured in order for federated instances to be contacted.